### PR TITLE
Added an option for volume for each sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ By default, reverb.nvim does ship with any sounds. To get started, configure the
     sounds = {
       -- add custom sound paths for other events here
       -- eg. EVENT = "/some/path/to/sound.mp3"
-      BufRead = sound_dir .. "start.ogg",
-      CursorMovedI =  sound_dir .. "click.ogg",
-      InsertLeave = sound_dir .. "toggle.ogg",
-      ExitPre = sound_dir .. "exit.ogg",
-      BufWrite = sound_dir .. "save.ogg",
+      BufRead = { path = sound_dir .. "start.ogg", volume = 0-100 },
+      CursorMovedI = { path = sound_dir .. "click.ogg", volume = 0-100 },
+      InsertLeave = { path = sound_dir .. "toggle.ogg", volume = 0-100 },
+      ExitPre = { path = sound_dir .. "exit.ogg", volume = 0-100 },
+      BufWrite = { path = sound_dir .. "save.ogg", volume = 0-100 },
     },
   },
 }

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -7,31 +7,31 @@ vim.api.nvim_create_augroup("reverb", {
 })
 
 -- Autocmd callback
-local cb = function(event, path)
-    if utils.path_exists(path) then
+local cb = function(event, sound)
+    if utils.path_exists(sound.path) then
         -- There could be other events?
         if event == "BufWrite" then
             -- only if the buffer has been modified ?
             local buf = vim.api.nvim_get_current_buf()
             local buf_modified = vim.api.nvim_buf_get_option(buf, "modified")
             if buf_modified then
-                utils.play_sound(path)
+                utils.play_sound(sound.path, sound.volume)
             end
         else
-            utils.play_sound(path)
+            utils.play_sound(sound.path, sound.volume)
         end
     end
 end
 
 -- Options are loaded from lua/reverb.lua
 M.load = function(opts)
-    for _, sound in pairs(opts) do
-        for event, path in pairs(sound) do
+    for _, sounds in pairs(opts) do
+        for event, sound in pairs(sounds) do
             vim.api.nvim_create_autocmd(event, {
                 group = "reverb",
                 pattern = "*",
                 callback = function()
-                    cb(event, path)
+                    cb(event, sound)
                 end,
             })
         end

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -9,7 +9,7 @@ end
 -- Play a sound using paplay
 M.play_sound = function(path, human_volume)
     local paplay_volume = convert_volume(human_volume)
-    vim.fn.system(string.format("paplay %s --volume-%d &", path, paplay_volume))
+    vim.fn.system(string.format("paplay %s --volume=%d &", path, paplay_volume))
 end
 
 -- Good old path exists function

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,12 +1,19 @@
 local M = {}
 
--- Play a sound using paplay
-M.play_sound = function (path)
-    vim.fn.system(string.format("paplay %s &", path))
+local function convert_volume(human_volume)
+    local clamped_volume = math.max(0, math.min(100, human_volume))
+    local paplay_volume = math.floor(clamped_volume * 655.36)
+    return paplay_volume
 end
 
--- Good old path exists function 
-M.path_exists = function (path)
+-- Play a sound using paplay
+M.play_sound = function(path, human_volume)
+    local paplay_volume = convert_volume(human_volume)
+    vim.fn.system(string.format("paplay %s --volume-%d &", path, paplay_volume))
+end
+
+-- Good old path exists function
+M.path_exists = function(path)
     local ok, err, code = os.rename(path, path)
     if not ok then
         if code == 13 then


### PR DESCRIPTION
This pull request introduces a new feature to the plugin, allowing users to specify volume levels for individual sounds using human-readable values (0-100). The input volume values are then correctly converted to the range expected by the `paplay` command (0-65536) before playing the sound.

The addition of volume control enhances the usability of the plugin by giving users the flexibility to adjust sound levels according to their preferences. This feature improves the overall user experience and makes the plugin more versatile.