### PR TITLE
Various features

### DIFF
--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -10,22 +10,23 @@ local missing_sounds = {}
 
 -- Autocmd callback
 local cb = function(event, sound)
-    if utils.path_exists(sound.path) then
+    local path = vim.fn.expand(sound.path)
+    if utils.path_exists(path) then
         -- There could be other events?
         if event == "BufWrite" then
             -- only if the buffer has been modified ?
             local buf = vim.api.nvim_get_current_buf()
             local buf_modified = vim.api.nvim_buf_get_option(buf, "modified")
             if buf_modified then
-                utils.play_sound(sound.path, sound.volume)
+                utils.play_sound(path, sound.volume)
             end
         else
-            utils.play_sound(sound.path, sound.volume)
+            utils.play_sound(path, sound.volume)
         end
     else
-        if not missing_sounds[sound.path] then
-            missing_sounds[sound.path] = true
-            print("file " .. sound.path .. "does not exist")
+        if not missing_sounds[path] then
+            missing_sounds[path] = true
+            print("file " .. path .. "does not exist")
         end
     end
 end

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -6,6 +6,8 @@ vim.api.nvim_create_augroup("reverb", {
     clear = true,
 })
 
+local missing_sounds = {}
+
 -- Autocmd callback
 local cb = function(event, sound)
     if utils.path_exists(sound.path) then
@@ -19,6 +21,11 @@ local cb = function(event, sound)
             end
         else
             utils.play_sound(sound.path, sound.volume)
+        end
+    else
+        if not missing_sounds[sound.path] then
+            missing_sounds[sound.path] = true
+            print("file " .. sound.path .. "does not exist")
         end
     end
 end

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local function convert_volume(human_volume)
+    human_volume = human_volume or 100
     local clamped_volume = math.max(0, math.min(100, human_volume))
     local paplay_volume = math.floor(clamped_volume * 655.36)
     return paplay_volume


### PR DESCRIPTION
* Volume for a sound effect is 100% by default.
* ~ expands to home in the sound paths
* When a sound effect is missing (for the first time), a message is printed.