### PR TITLE
fix: use `vim.system` instead of `vim.fn.system`

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -9,7 +9,7 @@ end
 -- Play a sound using paplay
 M.play_sound = function(path, human_volume)
     local paplay_volume = convert_volume(human_volume)
-    vim.fn.system(string.format("paplay %s --volume=%d &", path, paplay_volume))
+    vim.system({ 'paplay', path, '--volume', tostring(paplay_volume) })
 end
 
 -- Good old path exists function


### PR DESCRIPTION
As from the docs on `:h system()`, `vim.system` should be preferred in lua.

Not sure if this is true or a anecdote, but `vim.system` seems to perform better for me, too.

With your `vim.fn.system()` solution, my statusline blinked fairly commonly when playing sound effects.

With `vim.system`, it doesn't do that anymore.
