### PR TITLE
Add option to limit the amount of sounds playing at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ By default, reverb.nvim does *not* ship with any sounds. To get started, configu
   event = "BufReadPre",
   opts = {
     player = "pw-play" -- default: paplay
+    max_sounds = 20, -- Limit the amount of sounds that can play at the same time
     sounds = {
       -- add custom sound paths for other events here
       -- eg. EVENT = "/some/path/to/sound.mp3"

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -11,10 +11,12 @@ local missing_sounds = {}
 RUNNING_PROCESSES = 0
 
 -- Autocmd callback
-local cb = function(event, sound, player)
+local cb = function(event, sound, player, max_sounds)
     local path = vim.fn.expand(sound.path)
 
-    if RUNNING_PROCESSES >= 15 then
+    -- Don't play if enough processes are already playing
+    local max_running_processes = max_sounds or 20
+    if RUNNING_PROCESSES >= max_running_processes then
         return
     end
 
@@ -57,7 +59,7 @@ M.load = function(opts)
             group = "reverb",
             pattern = "*",
             callback = function()
-                cb(event, sound, opts.player)
+                cb(event, sound, opts.player, opts.max_sounds)
             end,
         })
     end

--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -8,9 +8,15 @@ vim.api.nvim_create_augroup("reverb", {
 
 local missing_sounds = {}
 
+RUNNING_PROCESSES = 0
+
 -- Autocmd callback
 local cb = function(event, sound, player)
     local path = vim.fn.expand(sound.path)
+
+    if RUNNING_PROCESSES >= 15 then
+        return
+    end
 
     -- Choose which player command should be used
     -- Choose paplay as default
@@ -28,9 +34,11 @@ local cb = function(event, sound, player)
             local buf = vim.api.nvim_get_current_buf()
             local buf_modified = vim.api.nvim_buf_get_option(buf, "modified")
             if buf_modified then
+                RUNNING_PROCESSES = RUNNING_PROCESSES + 1
                 player_function(path, sound.volume)
             end
         else
+            RUNNING_PROCESSES = RUNNING_PROCESSES + 1
             player_function(path, sound.volume)
         end
     else

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local function finished_playing()
+    RUNNING_PROCESSES = RUNNING_PROCESSES -1
+end
+
 -- Returns a value between 0.0 and 1.0
 local function convert_volume(human_volume)
     human_volume = human_volume or 100
@@ -11,14 +15,15 @@ end
 -- Play a sound using paplay
 M.paplay_play_sound = function(path, human_volume)
     local volume = math.floor(convert_volume(human_volume) * 65536.0)
-    vim.system({ 'paplay', path, '--volume', tostring(volume) })
+    vim.system({ 'paplay', path, '--volume', tostring(volume) }, {}, finished_playing)
 end
 
 -- Play a sound using pwplay
 M.pw_play_play_sound = function(path, human_volume)
     local volume = convert_volume(human_volume)
-    vim.system({ 'pw-play', path, '--volume', tostring(volume) })
+    vim.system({ 'pw-play', path, '--volume', tostring(volume) }, {}, finished_playing)
 end
+
 -- Good old path exists function
 M.path_exists = function(path)
     local ok, err, code = os.rename(path, path)


### PR DESCRIPTION
I mapped some sounds to CursorMove so when I hold down, I get blasted by 50 sounds playing all at the same time.

This should also just limit processes spawned when using more heavyweight players in the future (mpv?).

The implementation is hacky, as I don't know how "global" the global variable is, but it works™️

Thank you a lot btw for this plugin, I find it very fun :D

Edit: I apparently fucked up my branch name and called it max_options?? I meant max_sounds lol
