### PR TITLE
Niche feature request: support a list of audio files being passed as path

### DIFF
--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -10,13 +10,24 @@ local missing_sounds = {}
 
 RUNNING_PROCESSES = 0
 
+-- Helper function to pick a random sound file if 'sound.path' is a list
+local function get_sound_path(sound)
+    if type(sound.path) == "table" then
+        local index = math.random(#sound.path)
+        return vim.fn.expand(sound.path[index])
+    else
+        return vim.fn.expand(sound.path)
+    end
+end
+
 local cb = function(event, sound, player, max_sounds)
     -- Don't do anything if the plugin is disabled
     if not PLUGIN_ENABLED then
         return
     end
 
-    local path = vim.fn.expand(sound.path)
+    -- Get the path to the audio file
+    local path = get_sound_path(sound)
 
     -- Don't play if enough processes are already playing
     local max_running_processes = max_sounds or 20


### PR DESCRIPTION
I am currently using reverb.nvim to play typewriter sound effects, but I have 3 wav files that I want to play randomly after each TextChange effect. I just implemented an extra feature so the `path` field can also be a list of audio files, where reverb will randomly play one of the files when the event is triggered.

An example of what my config currently looks like:
```lua
{
  'willzeng274/reverb.nvim',
  event = 'BufReadPre',
  opts = {
    player = 'mpv', -- this is the only player that works well on my macos 15
    max_sounds = 20,
    sounds = {
      InsertEnter = { path = sound_dir .. 'carriage1.wav', volume = 50 },
      InsertLeave = { path = sound_dir .. 'ding1.wav', volume = 50 },
      TextChangedI = { path = { sound_dir .. 'click1.wav', sound_dir .. 'click2.wav', sound_dir .. 'click3.wav' }, volume = 50 },
      TextChangedP = { path = { sound_dir .. 'click1.wav', sound_dir .. 'click2.wav', sound_dir .. 'click3.wav' }, volume = 50 },
    },
  },
},
```